### PR TITLE
Change port and await for mongo db connection before starting server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-PORT=[3000] default value is 3000
+PORT=[8080] default value is 8080
 MONGO_URI=mongodb+srv://<DB_USERNAME>:<DB_PASSWORD>@<CLUSTER>/<DB_NAME>?retryWrites=true&w=majority
 ACCESS_TOKEN_SECRET = <access_token_secret_key>
 REFRESH_TOKEN_SECRET = <refresh_token_secret_key>

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,34 +6,42 @@ import path from 'path'
 
 dotenv.config()
 
-/***********************************
- *         Mongo DB Connection      *
- ***********************************/
-mongoose.Promise = Promise
-mongoose
-  .connect(`${process.env.MONGO_URI}`, {
-    useNewUrlParser: true,
-    useUnifiedTopology: true
-  } as ConnectOptions)
-  .then(() => {
-    console.log('MongoDB Connected')
-  })
-  .catch((err) => {
-    console.error('MongoDB Connection Error: ', err)
-  })
+const startApp = async () => {
+  try {
+    /***********************************
+     *         Mongo DB Connection      *
+     ***********************************/
 
-/***********************************
- *      Listening for requests     *
- ***********************************/
-const app: Express = express()
+    await mongoose
+      .connect(`${process.env.MONGO_URI}`, {
+        useNewUrlParser: true,
+        useUnifiedTopology: true
+      } as ConnectOptions)
+      .then(() => {
+        console.log('MongoDB Connected')
+      })
+      .catch((err) => {
+        console.error('MongoDB Connection Error: ', err)
+      })
 
-app.use(express.json())
+    /***********************************
+     *      Listening for requests     *
+     ***********************************/
+    const app: Express = express()
 
-app.use(express.static(path.join(__dirname, '../public')))
-app.use('/', router)
+    app.use(express.json())
 
-const port = process.env.PORT
+    app.use(express.static(path.join(__dirname, '../public')))
+    app.use('/', router)
 
-app.listen(`${port}`, () => {
-  console.log(`⚡️[server]: Server is running at http://localhost:${port}`)
-})
+    const port = process.env.PORT
+
+    app.listen(`${port}`, () => {
+      console.log(`⚡️[server]: Server is running at http://localhost:${port}`)
+    })
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+startApp()

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -80,10 +80,9 @@ const signup = async (body: UserPayload): Promise<SignupResponse> => {
   const user = new User({
     name: name,
     email: email,
-    address: address,
-    password: password
+    address: address
   })
-  await user.hashPassword()
+  user.password = User.hashPassword(password)
   await user.save()
   //user.password = await user.hashPassword(password)
   const accessToken = generateAccessToken(user.email)
@@ -109,9 +108,8 @@ const login = async (body: LoginPayload): Promise<TokenResponse> => {
     throw 'User not found'
   }
 
-  const isExpectedPassword = await user.comparePassword(password)
-  if (!isExpectedPassword) {
-    console.log('invalid')
+  const isCorrectPassword = user.comparePassword(password)
+  if (!isCorrectPassword) {
     throw 'Invalid credentials'
   }
 

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -80,10 +80,12 @@ const signup = async (body: UserPayload): Promise<SignupResponse> => {
   const user = new User({
     name: name,
     email: email,
-    address: address
+    address: address,
+    password: password
   })
+  await user.hashPassword()
   await user.save()
-  user.password = await user.hashPassword(password)
+  //user.password = await user.hashPassword(password)
   const accessToken = generateAccessToken(user.email)
   const refreshToken = generateRefreshToken(user.email)
   user.tokens = {
@@ -107,8 +109,9 @@ const login = async (body: LoginPayload): Promise<TokenResponse> => {
     throw 'User not found'
   }
 
-  const expectedPassword = await user.comparePassword(password, user.password)
-  if (!expectedPassword) {
+  const isExpectedPassword = await user.comparePassword(password)
+  if (!isExpectedPassword) {
+    console.log('invalid')
     throw 'Invalid credentials'
   }
 

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -1,4 +1,3 @@
-import bcrypt from 'bcrypt'
 import User, {
   LoginPayload,
   SignupResponse,
@@ -72,22 +71,19 @@ const signup = async (body: UserPayload): Promise<SignupResponse> => {
   // user creation
   // token generation
   const { name, email, address, password } = body
-
   const existingUser = await User.findOne({ email })
 
   if (existingUser) {
     throw 'User already exists.'
   }
 
-  const hashedPassword = await bcrypt.hash(password, 10)
-
   const user = new User({
     name: name,
     email: email,
-    address: address,
-    password: hashedPassword
+    address: address
   })
   await user.save()
+  user.password = await user.hashPassword(password)
   const accessToken = generateAccessToken(user.email)
   const refreshToken = generateRefreshToken(user.email)
   user.tokens = {
@@ -111,7 +107,7 @@ const login = async (body: LoginPayload): Promise<TokenResponse> => {
     throw 'User not found'
   }
 
-  const expectedPassword = await bcrypt.compare(password, user.password)
+  const expectedPassword = await user.comparePassword(password, user.password)
   if (!expectedPassword) {
     throw 'Invalid credentials'
   }

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,4 +1,5 @@
 import mongoose, { Model } from 'mongoose'
+import bcrypt from 'bcrypt'
 
 //import mongooseSequence from "mongoose-sequence";
 
@@ -32,7 +33,13 @@ export interface SessionResponse {
   address: string
 }
 
-export interface UserDocument extends UserResponse, Document {}
+export interface UserDocument extends UserResponse, Document {
+  hashPassword(password: string): Promise<string>
+  comparePassword(
+    enteredPassword: string,
+    hashedPassword: string
+  ): Promise<boolean>
+}
 
 export interface UpdatedUser {
   email: string
@@ -58,6 +65,16 @@ const UserSchema = new mongoose.Schema(
   { timestamps: true }
 )
 
+UserSchema.statics.hashPassword = async function (password: string) {
+  return await bcrypt.hash(password, 10)
+}
+
+UserSchema.statics.comparePassword = async function (
+  enteredPassword,
+  hashedPassword
+) {
+  return await bcrypt.compare(enteredPassword, hashedPassword)
+}
 //UserSchema.plugin(AutoIncrement, { inc_field: "id" });
 
 const User: Model<UserDocument> = mongoose.model<UserDocument>(

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -34,11 +34,8 @@ export interface SessionResponse {
 }
 
 export interface UserDocument extends UserResponse, Document {
-  hashPassword(password: string): Promise<string>
-  comparePassword(
-    enteredPassword: string,
-    hashedPassword: string
-  ): Promise<boolean>
+  hashPassword(): Promise<void>
+  comparePassword(enteredPassword: string): Promise<boolean>
 }
 
 export interface UpdatedUser {
@@ -65,16 +62,26 @@ const UserSchema = new mongoose.Schema(
   { timestamps: true }
 )
 
-UserSchema.statics.hashPassword = async function (password: string) {
-  return await bcrypt.hash(password, 10)
+UserSchema.methods.hashPassword = async function (): Promise<void> {
+  this.password = await bcrypt.hash(this.password, 10)
 }
 
-UserSchema.statics.comparePassword = async function (
-  enteredPassword,
-  hashedPassword
-) {
-  return await bcrypt.compare(enteredPassword, hashedPassword)
+UserSchema.methods.comparePassword = async function (
+  enteredPassword: string
+): Promise<boolean> {
+  return await bcrypt.compare(enteredPassword, this.password)
 }
+
+// UserSchema.statics.hashPassword = async function (password: string) {
+//   return await bcrypt.hash(password, 10)
+// }
+
+// UserSchema.statics.comparePassword = async function (
+//   enteredPassword,
+//   hashedPassword
+// ) {
+//   return await bcrypt.compare(enteredPassword, hashedPassword)
+// }
 //UserSchema.plugin(AutoIncrement, { inc_field: "id" });
 
 const User: Model<UserDocument> = mongoose.model<UserDocument>(

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -13,7 +13,7 @@ authRouter.post('/signup', async (req, res) => {
     const response = await controller.signup(req.body)
     return res.send(response)
   } catch (err: any) {
-    return res.status(err.code).send(err.message)
+    return res.status(409).send(err.message)
   }
 })
 
@@ -24,7 +24,7 @@ authRouter.post('/login', async (req, res) => {
     const response = await controller.login(req.body)
     return res.send(response)
   } catch (err: any) {
-    return res.status(err.code).send(err.message)
+    return res.status(401).send(err.message)
   }
 })
 


### PR DESCRIPTION
## Feature

​
Change port number and await for mongo db connection before starting server
​

## Intent

​
This PR intends to modify the .env.example file so that the default port number is 8080, and modifies the app.ts file so that the server awaits for the MongoDB connection before starting and listening to requests on the specified port.
​

## Implementation

​
* Created startApp function to await for the MongoDB connection before starting the server.
* Changed the port number to 8080
​

## Checks

These changes have been tested locally and have been verified to work as expected.
